### PR TITLE
UI: Bootstrap ready SignUpForm & LoginForm; update templates and tests

### DIFF
--- a/tasks/forms.py
+++ b/tasks/forms.py
@@ -1,9 +1,12 @@
+# tasks/forms.py
 from django import forms
 from django.utils import timezone
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
+from django.contrib.auth.models import User
 
 from .models import Task
 
-
+# Existing TaskForm (leave as-is)
 class TaskForm(forms.ModelForm):
     due_date = forms.DateField(
         widget=forms.DateInput(attrs={"type": "date"}), required=False
@@ -16,9 +19,7 @@ class TaskForm(forms.ModelForm):
             "title": forms.TextInput(attrs={"class": "form-control"}),
             "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
             "priority": forms.Select(attrs={"class": "form-select"}),
-            "due_date": forms.DateInput(
-                attrs={"class": "form-control", "type": "date"}
-            ),
+            "due_date": forms.DateInput(attrs={"class": "form-control", "type": "date"}),
             "is_completed": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
@@ -27,3 +28,53 @@ class TaskForm(forms.ModelForm):
         if due_date and due_date < timezone.now().date():
             raise forms.ValidationError("The date of entry cannot be in the past.")
         return due_date
+
+
+# Add this SignUpForm for (bootstrap attrs)
+class SignUpForm(UserCreationForm):
+    """Bootstrap-styled Django signup form."""
+
+    class Meta:
+        model = User
+        # include email so user can register with email
+        fields = ("username", "email", "password1", "password2")
+
+    def __init__(self, *args, **kwargs):
+        # call parent constructor
+        super().__init__(*args, **kwargs)
+        # iterate fields and set bootstrap classes & placeholder
+        for name, field in self.fields.items():
+            widget = field.widget
+            widget_name = widget.__class__.__name__.lower()
+
+            # default placeholder: field label
+            placeholder = field.label if field.label else name.capitalize()
+
+            if "checkbox" in widget_name:
+                widget.attrs.update({"class": "form-check-input"})
+            elif "select" in widget_name:
+                widget.attrs.update({"class": "form-select", "placeholder": placeholder})
+            else:
+                # text inputs, password inputs, email, etc.
+                widget.attrs.update({"class": "form-control", "placeholder": placeholder})
+
+
+# LOGIN FORM (Bootstrap attrs)
+class LoginForm(AuthenticationForm):
+    """Bootstrap-styled Django login form."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for name, field in self.fields.items():
+            placeholder = field.label or name.capitalize()
+            widget = field.widget
+            widget_type = widget.__class__.__name__.lower()
+
+            if "checkbox" in widget_type:
+                widget.attrs.update({"class": "form-check-input"})
+            else:
+                widget.attrs.update({
+                    "class": "form-control",
+                    "placeholder": placeholder
+                })

--- a/tasks/templates/registration/login.html
+++ b/tasks/templates/registration/login.html
@@ -2,22 +2,42 @@
 
 {% block content %}
 <div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-6">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <h2 class="card-title mb-4">Login</h2>
-                    <form method="post">
-                        {% csrf_token %}
-                        {{ form.as_p }}
-                        <button type="submit" class="btn btn-success w-100">Login</button>
-                    </form>
-                    <p class="mt-3 text-center">
-                        Don’t have an account? <a href="{% url 'signup' %}">Sign Up</a>
-                    </p>
-                </div>
-            </div>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h2 class="card-title mb-4 text-center">Login</h2>
+
+          <form method="post" novalidate>
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+              <div class="alert alert-danger">
+                {{ form.non_field_errors }}
+              </div>
+            {% endif %}
+
+            {% for field in form %}
+              <div class="mb-3">
+                <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+                {{ field }}
+                {% if field.errors %}
+                  <div class="form-text text-danger">
+                    {{ field.errors|striptags }}
+                  </div>
+                {% endif %}
+              </div>
+            {% endfor %}
+
+            <button type="submit" class="btn btn-primary w-100">Login</button>
+          </form>
+
+          <p class="mt-3 text-center">
+            <a href="{% url 'password_reset' %}">Forgot password?</a>
+          </p>
         </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock content %}

--- a/tasks/templates/tasks/signup.html
+++ b/tasks/templates/tasks/signup.html
@@ -2,22 +2,49 @@
 
 {% block content %}
 <div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-6">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <h2 class="card-title mb-4">Sign Up</h2>
-                    <form method="post">
-                        {% csrf_token %}
-                        {{ form.as_p }}
-                        <button type="submit" class="btn btn-primary w-100">Register</button>
-                    </form>
-                    <p class="mt-3 text-center">
-                        Already have an account? <a href="{% url 'login' %}">Login</a>
-                    </p>
-                </div>
-            </div>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h2 class="card-title mb-4 text-center">Sign Up</h2>
+
+          <form method="post" novalidate>
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+              <div class="alert alert-danger">
+                {{ form.non_field_errors }}
+              </div>
+            {% endif %}
+
+            {% for field in form %}
+              <div class="mb-3">
+                <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+
+                <!-- Simple rendering. Widget attributes are set in SignUpForm.__init__ -->
+                {{ field }}
+
+                {% if field.help_text %}
+                  <div class="form-text">{{ field.help_text }}</div>
+                {% endif %}
+
+                {% if field.errors %}
+                  <div class="form-text text-danger">
+                    {{ field.errors|striptags }}
+                  </div>
+                {% endif %}
+              </div>
+            {% endfor %}
+
+            <button type="submit" class="btn btn-primary w-100">Register</button>
+          </form>
+
+          <p class="mt-3 text-center">
+            Already have an account? <a href="{% url 'login' %}">Login</a>
+          </p>
         </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock content %}

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -196,3 +196,21 @@ class TaskViewTest(TestCase):
         response = self.client.get(url)
         tasks = response.context["tasks"]
         self.assertEqual(tasks[0].title, "Task 2")  # نزدیک‌ترین تاریخ باید اول باشد
+
+
+class AuthTests(TestCase):
+    def test_signup_create_user(self):
+        resp = self.client.post(reverse("signup"), {
+            "username":"testuser",
+            "email":"t@test.com",
+            "password1":"ComplexPass123!",
+            "password2":"ComplexPass123!"
+        })
+        # after signup, should redirect to login
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(User.objects.filter(username="testuser").exists())
+
+    def test_login(self):
+        User.objects.create_user(username="u1", password="pwdStrong1!")
+        resp = self.client.post(reverse("login"), {"username":"u1","password":"pwdStrong1!"})
+        self.assertIn(resp.status_code, (302, 301))

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -2,10 +2,15 @@ from django.contrib.auth import views as auth_views
 from django.urls import path
 
 from . import views
+from .forms import LoginForm
 
 urlpatterns = [
     path("signup/", views.SignUpView.as_view(), name="signup"),
-    path("login/", auth_views.LoginView.as_view(), name="login"),
+    path("login/", auth_views.LoginView.as_view(
+            template_name="registration/login.html",
+            authentication_form=LoginForm,
+        ), 
+        name="login"),
     path("", views.HomeView.as_view(), name="home"),
     path("tasks/", views.TaskListView.as_view(), name="task_list"),
     path("tasks/create/", views.TaskCreateView.as_view(), name="task_create"),

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -6,14 +6,13 @@ from django.urls import reverse_lazy
 from django.views.generic import (CreateView, DeleteView, ListView,
                                   TemplateView, UpdateView)
 
-from .forms import TaskForm
+from .forms import TaskForm,SignUpForm,LoginForm
 from .models import Task
 
+
 # Create your views here.
-
-
 class SignUpView(CreateView):
-    form_class = UserCreationForm
+    form_class = SignUpForm        # use our form with bootstrap attrs
     template_name = "tasks/signup.html"
     success_url = reverse_lazy("login")
 


### PR DESCRIPTION
Summary
- Converted signup and login templates to explicit field rendering (no as_widget(attrs=...)).
- Added SignUpForm and LoginForm to set Bootstrap widget attributes in Python.
- Wired default LoginView to use LoginForm via urls.
- Updated tests to ensure signup/login and task flows continue working.

How to test locally
1. python -m venv venv && venv\Scripts\activate   # Windows
2. pip install -r requirements.txt
3. python manage.py migrate
4. python manage.py runserver
5. Visit /signup/ and /login/ to verify Bootstrap styling and proper validation.
6. Run tests: python manage.py test

Notes
- No business logic changes; only UI + templates + forms + tests.
- Happy to adjust Bootstrap CDN or minor UI pieces if maintainers prefer.
